### PR TITLE
fix: Use tokio from runner crate for generated code

### DIFF
--- a/runner-macros/src/entry.rs
+++ b/runner-macros/src/entry.rs
@@ -110,8 +110,8 @@ fn parse_knobs(
         {
             #rt
             let body = async #body;
-            let mut rt = tokio::runtime::Runtime::new().unwrap();
-            let local = tokio::task::LocalSet::new();
+            let mut rt = runner::__private::tokio::runtime::Runtime::new().unwrap();
+            let local = runner::__private::tokio::task::LocalSet::new();
             local.block_on(&mut rt, body);
         }
     })

--- a/runner/src/lib.rs
+++ b/runner/src/lib.rs
@@ -7,4 +7,9 @@ pub use runtime::SandboxRuntime;
 #[cfg(not(test))] // Work around for rust-lang/rust#62127
 pub use runner_macros::main;
 
+// Used for generated code, Not a public API
+#[doc(hidden)]
+#[path = "private/mod.rs"]
+pub mod __private;
+
 pub use rpc::api::*;

--- a/runner/src/private/mod.rs
+++ b/runner/src/private/mod.rs
@@ -1,0 +1,1 @@
+pub use tokio;


### PR DESCRIPTION
The issue is that when using the `#[runner::test]` when you don't import tokio manually will have issues. This will also allow us to swap out the runtime with alternatives if we want later without adding breaking changes.

I'm using a pattern that serde uses, and I don't know if there is a cleaner way but this is the way I'm familiar with. cc @matklad do you think there is a better pattern for this?